### PR TITLE
Add copy icon utilities

### DIFF
--- a/src/ui_capture.py
+++ b/src/ui_capture.py
@@ -1,0 +1,36 @@
+import pyautogui
+from typing import Optional, Tuple
+
+# Placeholder: in the future, read template paths from config.yml
+_TEMPLATE_PATHS = []  # TODO: populate from config.yml
+
+
+def locate_copy_icon(region=None) -> Optional[Tuple[int, int, int, int]]:
+    """Locate the ChatGPT Desktop Copy button on screen.
+
+    Parameters
+    ----------
+    region : tuple, optional
+        A region tuple (left, top, width, height) to restrict the search.
+
+    Returns
+    -------
+    tuple or None
+        Bounding box of the located icon or None if not found.
+    """
+    for path in _TEMPLATE_PATHS:
+        box = pyautogui.locateOnScreen(path, region=region)
+        if box:
+            return box
+    return None
+
+
+def click_copy_icon() -> bool:
+    """Move the mouse to the Copy icon and click if found."""
+    box = locate_copy_icon()
+    if box:
+        center_x, center_y = pyautogui.center(box)
+        pyautogui.moveTo(center_x, center_y)
+        pyautogui.click()
+        return True
+    return False

--- a/tests/test_ui_capture.py
+++ b/tests/test_ui_capture.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import types
+
+# Ensure src package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+# Provide a minimal pyautogui stub so tests run without a display
+pyautogui_stub = types.SimpleNamespace(
+    locateOnScreen=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    click=lambda *a, **k: None,
+    center=lambda box: (box[0] + box[2] / 2, box[1] + box[3] / 2),
+)
+sys.modules['pyautogui'] = pyautogui_stub
+
+import ui_capture
+from ui_capture import click_copy_icon
+
+
+def test_click_copy_icon_found(monkeypatch):
+    called = {}
+
+    def fake_locate(*args, **kwargs):
+        return (10, 20, 30, 40)
+
+    def fake_click():
+        called['clicked'] = True
+
+    def fake_move(x, y):
+        called['moved'] = (x, y)
+
+    monkeypatch.setattr(pyautogui_stub, 'locateOnScreen', fake_locate)
+    monkeypatch.setattr(pyautogui_stub, 'click', fake_click)
+    monkeypatch.setattr(pyautogui_stub, 'moveTo', fake_move)
+    monkeypatch.setattr(ui_capture, '_TEMPLATE_PATHS', ['dummy'])
+
+    result = click_copy_icon()
+
+    assert result is True
+    assert called.get('clicked') is True
+    assert called.get('moved') == pyautogui_stub.center((10, 20, 30, 40))
+
+
+def test_click_copy_icon_not_found(monkeypatch):
+    called = {}
+
+    def fake_locate(*args, **kwargs):
+        return None
+
+    def fake_click():
+        called['clicked'] = True
+
+    monkeypatch.setattr(pyautogui_stub, 'locateOnScreen', fake_locate)
+    monkeypatch.setattr(pyautogui_stub, 'click', fake_click)
+    monkeypatch.setattr(pyautogui_stub, 'moveTo', lambda *a, **k: called.__setitem__('moved', True))
+    monkeypatch.setattr(ui_capture, '_TEMPLATE_PATHS', ['dummy'])
+
+    result = click_copy_icon()
+
+    assert result is False
+    assert 'clicked' not in called
+    assert 'moved' not in called


### PR DESCRIPTION
## Summary
- add `locate_copy_icon` and `click_copy_icon` helpers
- create tests for clicking behavior without real pyautogui

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d9ad888c832f8e49cebf345c1778