### PR TITLE
Add text chunking utility and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ python-xlib>=0.33 ; sys_platform != "win32"      # no effect on Windows  :conten
 # optional extras
 # pytesseract==0.3.10
 # pyinstaller==6.5.0
+langchain>=0.2.0
+tiktoken>=0.6.0

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.chunking import split_text
+
+
+class DummySplitter:
+    def __init__(self, chunk_size, chunk_overlap, separators):
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.sep = separators[0]
+
+    def split_text(self, text):
+        pieces = [p + self.sep for p in text.split(self.sep) if p]
+        chunks = []
+        for piece in pieces:
+            start = 0
+            while start < len(piece):
+                end = start + self.chunk_size
+                chunks.append(piece[start:end])
+                start = end - self.chunk_overlap
+        return chunks
+
+
+def stub_from_tiktoken_encoder(chunk_size=1500, chunk_overlap=200, separators=None):
+    return DummySplitter(chunk_size, chunk_overlap, separators or ["</p>"])
+
+
+def test_html_paragraph_split(monkeypatch):
+    from langchain.text_splitter import CharacterTextSplitter
+    monkeypatch.setattr(CharacterTextSplitter, "from_tiktoken_encoder", stub_from_tiktoken_encoder)
+    text = "<p>one</p><p>two</p>"
+    chunks = split_text(text, size=50, overlap=0)
+    assert chunks == ["<p>one</p>", "<p>two</p>"]
+
+
+def test_overlap(monkeypatch):
+    from langchain.text_splitter import CharacterTextSplitter
+    monkeypatch.setattr(CharacterTextSplitter, "from_tiktoken_encoder", stub_from_tiktoken_encoder)
+    text = "abcdefghi"
+    chunks = split_text(text, size=5, overlap=2)
+    assert chunks[1].startswith(chunks[0][-2:])

--- a/utils/chunking.py
+++ b/utils/chunking.py
@@ -1,0 +1,11 @@
+from langchain.text_splitter import CharacterTextSplitter
+
+
+def split_text(text: str, size: int = 1500, overlap: int = 200) -> list[str]:
+    """Split ``text`` into chunks using a tiktoken-based splitter."""
+    splitter = CharacterTextSplitter.from_tiktoken_encoder(
+        chunk_size=size,
+        chunk_overlap=overlap,
+        separators=["</p>", "\n\n"],
+    )
+    return splitter.split_text(text)


### PR DESCRIPTION
## Summary
- add `split_text` helper using LangChain
- cover HTML paragraph splitting and overlap behavior
- include LangChain and tiktoken in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dadcde54832f8aebc6a55f6f4d23