### PR TITLE
Add LanguageTool check to epub flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ python-xlib>=0.33 ; sys_platform != "win32"      # no effect on Windows  :conten
 langchain>=0.2.0
 tiktoken>=0.6.0
 click>=8.0
+language-tool-python>=2.9.4

--- a/tests/test_languagetool.py
+++ b/tests/test_languagetool.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+import pytest
+
+# Stub GUI and language tool modules before importing the module under test
+pyautogui_stub = types.SimpleNamespace()
+pygetwindow_stub = types.SimpleNamespace()
+pyperclip_stub = types.SimpleNamespace()
+sys.modules['pyautogui'] = pyautogui_stub
+sys.modules['pygetwindow'] = pygetwindow_stub
+sys.modules['pyperclip'] = pyperclip_stub
+sys.modules['language_tool_python'] = types.SimpleNamespace(LanguageTool=lambda *a, **k: None)
+
+# Ensure src package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src import process_epub
+
+class DummyBot:
+    def __init__(self):
+        self.calls = []
+    def _focus(self):
+        self.calls.append('focus')
+    def _paste(self, text, hit_enter=False):
+        self.calls.append(('paste', text, hit_enter))
+
+
+def test_retry_success(monkeypatch):
+    bot = DummyBot()
+    responses = ['bad text', 'good text']
+    monkeypatch.setattr(process_epub, 'read_response', lambda: responses.pop(0))
+    tool = types.SimpleNamespace(check=lambda txt: [1, 2, 3, 4] if txt == 'bad text' else [])
+    result = process_epub.ask_gpt(bot, 'prompt', tool)
+    assert result == 'good text'
+    assert len(bot.calls) == 4  # focus/paste twice
+
+
+def test_retry_failure(monkeypatch):
+    bot = DummyBot()
+    responses = ['bad', 'still bad']
+    monkeypatch.setattr(process_epub, 'read_response', lambda: responses.pop(0))
+    tool = types.SimpleNamespace(check=lambda txt: [1] * 4)
+    with pytest.raises(RuntimeError):
+        process_epub.ask_gpt(bot, 'prompt', tool)

--- a/tests/test_process_epub.py
+++ b/tests/test_process_epub.py
@@ -16,6 +16,7 @@ pyperclip_stub = types.SimpleNamespace(copy=lambda *a, **k: None, paste=lambda: 
 sys.modules['pyautogui'] = pyautogui_stub
 sys.modules['pygetwindow'] = pygetwindow_stub
 sys.modules['pyperclip'] = pyperclip_stub
+sys.modules['language_tool_python'] = types.SimpleNamespace(LanguageTool=lambda *a, **k: types.SimpleNamespace(check=lambda *_: []))
 
 class DummySplitter:
     def __init__(self, chunk_size, chunk_overlap, separators):
@@ -108,7 +109,7 @@ def test_process_epub(tmp_path, monkeypatch):
     monkeypatch.setattr(process_epub, 'ChatGPTAutomation', DummyBot)
     from langchain.text_splitter import CharacterTextSplitter
     monkeypatch.setattr(CharacterTextSplitter, 'from_tiktoken_encoder', stub_from_tiktoken_encoder)
-    monkeypatch.setattr(process_epub, 'ask_gpt', lambda bot, text: text.upper())
+    monkeypatch.setattr(process_epub, 'ask_gpt', lambda bot, text, tool: text.upper())
     monkeypatch.setattr(process_epub.subprocess, 'run', lambda *a, **k: types.SimpleNamespace(returncode=0, stdout='', stderr=''))
 
     from click.testing import CliRunner


### PR DESCRIPTION
## Summary
- check ChatGPT output with language_tool_python
- retry once if too many issues
- test LanguageTool retry logic
- stub new dependency in process_epub tests
- require `language-tool-python` library

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ea22d018832fa7beb6a04a814e27