### PR TITLE
Add keyboard shortcuts for EPUB processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ __pycache__/
 .idea/
 .DS_Store
 Thumbs.db
+
+## Usage
+
+Run `python -m src.main` to start the formatter.
+
+- **Ctrl+Shift+E** opens a file dialog to select an EPUB and an output
+  location. The chosen book is processed using ChatGPT and saved to the
+  specified file.
+- **Ctrl+Shift+Q** exits the application.

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,47 @@
-from src.automation import ChatGPTAutomation 
+"""Keyboard shortcuts for running the EPUB formatter."""
+
+import sys
+
+import keyboard
+import tkinter as tk
+from tkinter import filedialog
+
+from src.automation import ChatGPTAutomation
+from src.process_epub import main as process_epub
+
+
+def choose_epub() -> None:
+    """Open file dialogs to process an EPUB."""
+    root = tk.Tk()
+    root.withdraw()
+
+    in_path = filedialog.askopenfilename(
+        title="Select EPUB", filetypes=[("EPUB files", "*.epub")]
+    )
+    if not in_path:
+        return
+
+    out_path = filedialog.asksaveasfilename(
+        title="Save Processed EPUB",
+        defaultextension=".epub",
+        filetypes=[("EPUB files", "*.epub")],
+    )
+    if not out_path:
+        return
+
+    process_epub.callback(in_path, out_path)
+
+
+def quit_program() -> None:
+    """Unhook hotkeys and exit."""
+    keyboard.unhook_all_hotkeys()
+    sys.exit(0)
 
 if __name__ == "__main__":
     bot = ChatGPTAutomation("You are a helpful assistant.")
     bot.bootstrap()
+
+    keyboard.add_hotkey("ctrl+shift+e", choose_epub)
+    keyboard.add_hotkey("ctrl+shift+q", quit_program)
+
+    keyboard.wait()


### PR DESCRIPTION
## Summary
- add hotkeys to launch the formatter via Tk dialogs
- allow Ctrl+Shift+Q to exit
- document new shortcuts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ec803d68832fb575c606a2944d74