### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q
+      - name: Build on Windows
+        if: runner.os == 'Windows'
+        run: ./build_win.bat
+        shell: cmd
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow running on Ubuntu and Windows
- install dependencies using pip cache and run pytest
- attempt Windows build with `build_win.bat` but ignore failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f1c793c8832fb66aa2f7bf21b703