### PR TITLE
Add YAML config loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ langchain>=0.2.0
 tiktoken>=0.6.0
 click>=8.0
 language-tool-python>=2.9.4
+pyyaml>=6.0

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,49 @@
+import yaml
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yml"
+
+DEFAULT_CONFIG = {
+    "copy_icon_templates": [
+        "assets/icons/copy_light.png",
+        "assets/icons/copy_dark.png",
+    ],
+    "chunk_size": 1500,
+    "chunk_overlap": 200,
+    "typing_indicator_bbox": [1150, 850, 50, 20],
+}
+
+
+def _load_config(path: Path = CONFIG_PATH) -> dict:
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        except Exception:
+            data = {}
+    else:
+        data = {}
+    changed = False
+    for key, value in DEFAULT_CONFIG.items():
+        if key not in data:
+            data[key] = value
+            changed = True
+    if changed:
+        try:
+            with path.open("w", encoding="utf-8") as f:
+                yaml.safe_dump(data, f)
+        except Exception:
+            pass
+    return data
+
+
+_config = _load_config()
+copy_icon_templates = _config["copy_icon_templates"]
+chunk_size = _config["chunk_size"]
+chunk_overlap = _config["chunk_overlap"]
+typing_indicator_bbox = _config["typing_indicator_bbox"]
+
+
+def get_copy_icons() -> list:
+    """Return list of template image paths for the Copy icon."""
+    return list(copy_icon_templates)

--- a/src/ui_capture.py
+++ b/src/ui_capture.py
@@ -1,11 +1,10 @@
 import pyautogui
 from typing import Optional, Tuple
 
-# Placeholder: in the future, read template paths from config.yml
-_TEMPLATE_PATHS = [
-    "assets/icons/copy_light.png",
-    "assets/icons/copy_dark.png",
-]
+from src import config
+
+# Trigger config loading and retain for backward compatibility
+_TEMPLATE_PATHS = config.get_copy_icons()
 
 
 def locate_copy_icon(region=None) -> Optional[Tuple[int, int, int, int]]:
@@ -21,7 +20,7 @@ def locate_copy_icon(region=None) -> Optional[Tuple[int, int, int, int]]:
     tuple or None
         Bounding box of the located icon or None if not found.
     """
-    for path in _TEMPLATE_PATHS:
+    for path in config.copy_icon_templates:
         box = pyautogui.locateOnScreen(path, region=region)
         if box:
             return box

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,41 @@
+import importlib
+import io
+from pathlib import Path
+
+import yaml
+
+import src.config as config
+
+
+def test_defaults_created(monkeypatch):
+    fake_file = io.StringIO()
+
+    monkeypatch.setattr(config, 'CONFIG_PATH', Path('dummy.yml'))
+    monkeypatch.setattr(Path, 'exists', lambda self: False)
+    monkeypatch.setattr(Path, 'open', lambda self, mode='r', encoding=None: fake_file)
+    monkeypatch.setattr(yaml, 'safe_dump', lambda data, stream: None)
+    monkeypatch.setattr(yaml, 'safe_load', lambda *a, **k: {})
+
+    cfg = importlib.reload(config)
+
+    assert cfg.copy_icon_templates == cfg.DEFAULT_CONFIG['copy_icon_templates']
+    assert cfg.chunk_size == cfg.DEFAULT_CONFIG['chunk_size']
+    assert cfg.chunk_overlap == cfg.DEFAULT_CONFIG['chunk_overlap']
+    assert cfg.typing_indicator_bbox == cfg.DEFAULT_CONFIG['typing_indicator_bbox']
+
+
+def test_partial_config(monkeypatch):
+    fake_file = io.StringIO()
+
+    monkeypatch.setattr(config, 'CONFIG_PATH', Path('dummy.yml'))
+    monkeypatch.setattr(Path, 'exists', lambda self: True)
+    monkeypatch.setattr(Path, 'open', lambda self, mode='r', encoding=None: fake_file)
+    monkeypatch.setattr(yaml, 'safe_load', lambda *a, **k: {'chunk_size': 42})
+    monkeypatch.setattr(yaml, 'safe_dump', lambda data, stream: None)
+
+    cfg = importlib.reload(config)
+
+    assert cfg.chunk_size == 42
+    assert cfg.chunk_overlap == cfg.DEFAULT_CONFIG['chunk_overlap']
+    assert cfg.copy_icon_templates == cfg.DEFAULT_CONFIG['copy_icon_templates']
+    assert cfg.typing_indicator_bbox == cfg.DEFAULT_CONFIG['typing_indicator_bbox']

--- a/tests/test_ui_capture.py
+++ b/tests/test_ui_capture.py
@@ -16,6 +16,7 @@ sys.modules['pyautogui'] = pyautogui_stub
 
 import ui_capture
 from ui_capture import click_copy_icon
+import config
 
 
 def test_click_copy_icon_found(monkeypatch):
@@ -33,7 +34,7 @@ def test_click_copy_icon_found(monkeypatch):
     monkeypatch.setattr(pyautogui_stub, 'locateOnScreen', fake_locate)
     monkeypatch.setattr(pyautogui_stub, 'click', fake_click)
     monkeypatch.setattr(pyautogui_stub, 'moveTo', fake_move)
-    monkeypatch.setattr(ui_capture, '_TEMPLATE_PATHS', ['dummy'])
+    monkeypatch.setattr(config, 'copy_icon_templates', ['dummy'])
 
     result = click_copy_icon()
 
@@ -54,7 +55,7 @@ def test_click_copy_icon_not_found(monkeypatch):
     monkeypatch.setattr(pyautogui_stub, 'locateOnScreen', fake_locate)
     monkeypatch.setattr(pyautogui_stub, 'click', fake_click)
     monkeypatch.setattr(pyautogui_stub, 'moveTo', lambda *a, **k: called.__setitem__('moved', True))
-    monkeypatch.setattr(ui_capture, '_TEMPLATE_PATHS', ['dummy'])
+    monkeypatch.setattr(config, 'copy_icon_templates', ['dummy'])
 
     result = click_copy_icon()
 


### PR DESCRIPTION
## Summary
- add new `config.py` for YAML configuration with defaults
- load copy icon templates from config in `ui_capture`
- update tests to reflect config handling
- add tests covering config defaults
- require `pyyaml` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686709d908d8832f84a190cf0d469a43