### PR TITLE
Improve read_response error handling

### DIFF
--- a/src/automation.py
+++ b/src/automation.py
@@ -1,5 +1,5 @@
 import time, pyautogui as pag, pygetwindow as gw, pyperclip
-import subprocess, os, pathlib
+import subprocess, os, pathlib, sys
 
 # Determine the location of the ChatGPT desktop executable. ``pathlib.Path``
 # does not provide ``expandvars`` like ``os.path`` does, so we expand the
@@ -73,18 +73,20 @@ def wait_until_typing_stops(bbox=(1150, 850, 50, 20), timeout=30):
     raise RuntimeError("Timed out waiting for typing to stop")
 
 
-def read_response():
+def read_response(verbose: bool = False):
     """Retrieve the assistant's response from the ChatGPT Desktop UI."""
     wait_until_typing_stops()
 
+    text = ""
     try:
         import ui_capture
 
         ui_capture.click_copy_icon()
-    except Exception:
-        pass
+        text = pyperclip.paste()
+    except Exception as e:
+        if verbose:
+            print(f"Failed to read clipboard via copy icon: {e}", file=sys.stderr)
 
-    text = pyperclip.paste()
     if not text:
         pag.hotkey("ctrl", "a")
         pag.hotkey("ctrl", "c")

--- a/tests/test_read_response.py
+++ b/tests/test_read_response.py
@@ -65,3 +65,23 @@ def test_read_response_fallback_success(monkeypatch):
     assert result == 'fallback text'
     assert hotkeys == [('ctrl', 'a'), ('ctrl', 'c')]
 
+
+def test_read_response_error_logs(monkeypatch, capsys):
+    hotkeys.clear()
+
+    def raise_error():
+        raise RuntimeError('fail')
+
+    ui_stub = types.SimpleNamespace(click_copy_icon=raise_error)
+    monkeypatch.setitem(sys.modules, 'ui_capture', ui_stub)
+
+    paste_values = ['fallback text']
+    monkeypatch.setattr(pyperclip_stub, 'paste', lambda: paste_values.pop(0))
+
+    result = automation.read_response(verbose=True)
+
+    assert result == 'fallback text'
+    assert hotkeys == [('ctrl', 'a'), ('ctrl', 'c')]
+    captured = capsys.readouterr()
+    assert 'fail' in captured.err
+


### PR DESCRIPTION
## Summary
- add optional verbose parameter to `read_response`
- log clipboard errors to stderr
- clean up bare exception handler
- test that error path logs message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686709ea878c832fa1dda5f965e05825