### PR TITLE
Add Windows build script and artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
           powershell ./build_win.bat
         continue-on-error: true
 
+      - name: Upload Windows artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: BookEaseFormatter.exe
+          path: dist/BookEaseFormatter.exe
+
   second-job:
     strategy:
       matrix:

--- a/build_win.bat
+++ b/build_win.bat
@@ -1,0 +1,3 @@
+@echo off
+py -m pip install pyinstaller
+py -m PyInstaller --onefile src\main.py --name BookEaseFormatter


### PR DESCRIPTION
## Summary
- add a `build_win.bat` script for PyInstaller builds
- update CI workflow to upload the Windows executable artifact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670a133800832fa4bf5ce4d6cdd586