### PR TITLE
Handle clipboard delays and simplify chunking

### DIFF
--- a/src/automation.py
+++ b/src/automation.py
@@ -87,6 +87,7 @@ def read_response(verbose: bool = False):
         import ui_capture
 
         ui_capture.click_copy_icon()
+        time.sleep(0.2)
         text = pyperclip.paste()
     except Exception as e:
         if verbose:
@@ -95,7 +96,11 @@ def read_response(verbose: bool = False):
     if not text:
         pag.hotkey("ctrl", "a")
         pag.hotkey("ctrl", "c")
+        time.sleep(0.2)
         text = pyperclip.paste()
+        if not text:
+            time.sleep(0.2)
+            text = pyperclip.paste()
 
     if not text:
         raise RuntimeError("Clipboard did not contain any text")

--- a/utils/chunking.py
+++ b/utils/chunking.py
@@ -1,11 +1,20 @@
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-
-
 def split_text(text: str, size: int = 1500, overlap: int = 200) -> list[str]:
-    """Split ``text`` into chunks using a tiktoken-based splitter."""
-    splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(
-        chunk_size=size,
-        chunk_overlap=overlap,
-        keep_separator=False,
-    )
-    return splitter.split_text(text)
+    """Split ``text`` into overlapping chunks without external dependencies."""
+
+    raw_parts = text.split("</p>")
+    pieces = []
+    for i, part in enumerate(raw_parts):
+        if not part:
+            continue
+        if i < len(raw_parts) - 1:
+            pieces.append(part + "</p>")
+        else:
+            pieces.append(part)
+    chunks: list[str] = []
+    for piece in pieces:
+        start = 0
+        while start < len(piece):
+            end = start + size
+            chunks.append(piece[start:end])
+            start = end - overlap
+    return chunks


### PR DESCRIPTION
## Summary
- make `read_response` more tolerant of delayed clipboard updates
- replace langchain-based chunking with a lightweight implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867edd16fa4832f8bbb33a70a762374