### PR TITLE
Add prompt_factory module and update prompts

### DIFF
--- a/src/prompt_factory.py
+++ b/src/prompt_factory.py
@@ -1,0 +1,18 @@
+SYSTEM_TEMPLATE = """You are BookEase Formatter — an EPUB repair assistant.
+• Keep original meaning; correct spelling, XHTML validity, CSS syntax.
+• Never invent missing content.
+• Output SAME element you received, nothing more, nothing less.
+• Do not add commentary.
+"""
+
+
+def build_system_prompt() -> str:
+    return SYSTEM_TEMPLATE
+
+
+def build_user_prompt(file_path: str, chunk_id: int, total: int, chunk: str) -> str:
+    return (
+        f"<file>{file_path}</file>\n"
+        f"<chunk id='{chunk_id}/{total}'>\n{chunk}\n</chunk>"
+    )
+

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -105,9 +105,9 @@ def test_chunk_count(tmp_path, monkeypatch):
     monkeypatch.setattr(process_epub, 'split_text', stub_split)
 
     calls = []
-    def record(bot, text, tool):
-        calls.append(text)
-        return text
+    def record(bot, path, idx, total, chunk, tool):
+        calls.append(chunk)
+        return chunk
     monkeypatch.setattr(process_epub, 'ask_gpt', record)
 
     from click.testing import CliRunner

--- a/tests/test_languagetool.py
+++ b/tests/test_languagetool.py
@@ -31,7 +31,7 @@ def test_retry_success(monkeypatch):
     responses = ['bad text', 'good text']
     monkeypatch.setattr(process_epub, 'read_response', lambda: responses.pop(0))
     tool = types.SimpleNamespace(check=lambda txt: [1, 2, 3, 4] if txt == 'bad text' else [])
-    result = process_epub.ask_gpt(bot, 'prompt', tool)
+    result = process_epub.ask_gpt(bot, 'file', 1, 1, 'prompt', tool)
     assert result == 'good text'
     assert len(bot.calls) == 4  # focus/paste twice
 
@@ -42,4 +42,4 @@ def test_retry_failure(monkeypatch):
     monkeypatch.setattr(process_epub, 'read_response', lambda: responses.pop(0))
     tool = types.SimpleNamespace(check=lambda txt: [1] * 4)
     with pytest.raises(RuntimeError):
-        process_epub.ask_gpt(bot, 'prompt', tool)
+        process_epub.ask_gpt(bot, 'file', 1, 1, 'prompt', tool)

--- a/tests/test_prompt_factory.py
+++ b/tests/test_prompt_factory.py
@@ -1,0 +1,19 @@
+import importlib
+
+import src.prompt_factory as prompt_factory
+
+EXPECTED_SYSTEM = """You are BookEase Formatter — an EPUB repair assistant.
+• Keep original meaning; correct spelling, XHTML validity, CSS syntax.
+• Never invent missing content.
+• Output SAME element you received, nothing more, nothing less.
+• Do not add commentary.
+"""
+
+
+def test_system_prompt():
+    assert prompt_factory.build_system_prompt() == EXPECTED_SYSTEM
+
+
+def test_user_prompt():
+    user = prompt_factory.build_user_prompt('path.xhtml', 1, 3, '<p>hi</p>')
+    assert user == "<file>path.xhtml</file>\n<chunk id='1/3'>\n<p>hi</p>\n</chunk>"


### PR DESCRIPTION
## Summary
- create `prompt_factory` helper for prompts
- use `prompt_factory` in `process_epub` to send system and user messages
- add tests for new prompt module
- update process epub tests for prompt usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f71375f4832faaf2d6a7bd8ed5de