### PR TITLE
Add environment overrides for ChatGPT automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ You can also run the CLI directly:
 python -m src.process_epub --input mybook.epub --output cleaned.epub
 ```
 
+### Environment variables
+
+The application searches for the ChatGPT Desktop window titled `ChatGPT` and
+launches the executable from a default location. You can override these defaults
+with the following variables:
+
+- `CHATGPT_EXE` – full path to `ChatGPT.exe`.
+- `CHATGPT_WINDOW_TITLE` – title of the ChatGPT window to focus on.
+
 ## Development workflow
 1. Take or open a Codex task for the change you want to make.
 2. Run `git pull` to ensure `main` is up to date.

--- a/src/automation.py
+++ b/src/automation.py
@@ -4,16 +4,28 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
-# Determine the location of the ChatGPT desktop executable. ``pathlib.Path``
-# does not provide ``expandvars`` like ``os.path`` does, so we expand the
-# environment variables in the string first and then create a ``Path`` object.
+# Determine the location of the ChatGPT desktop executable.
+# ``pathlib.Path`` does not provide ``expandvars`` like ``os.path`` does, so we
+# expand the environment variables in the string first and then create a
+# ``Path`` object. Users can override this path with the ``CHATGPT_EXE``
+# environment variable.
 CHATGPT_EXE = pathlib.Path(
-    r"C:\Users\ZBook\AppData\Local\Microsoft\WindowsApps\ChatGPT.exe"
+    os.path.expanduser(
+        os.path.expandvars(
+            os.environ.get(
+                "CHATGPT_EXE",
+                r"C:\Users\ZBook\AppData\Local\Microsoft\WindowsApps\ChatGPT.exe",
+            )
+        )
+    )
 )
+
+# Allow customising the ChatGPT window title via ``CHATGPT_WINDOW_TITLE``.
+DEFAULT_WINDOW_TITLE = os.environ.get("CHATGPT_WINDOW_TITLE", "ChatGPT")
 
 
 class ChatGPTAutomation:
-    def __init__(self, system_prompt: str, window_title="ChatGPT"):
+    def __init__(self, system_prompt: str, window_title: str = DEFAULT_WINDOW_TITLE):
         self.system_prompt = system_prompt
         self.window_title = window_title
 

--- a/tests/test_automation_core.py
+++ b/tests/test_automation_core.py
@@ -107,3 +107,20 @@ def test_paste(monkeypatch):
     assert ('hotkey', ('ctrl', 'v')) in calls
     assert ('press', 'enter') in calls
 
+
+def test_env_overrides(monkeypatch):
+    monkeypatch.setenv('CHATGPT_WINDOW_TITLE', 'Foo')
+    monkeypatch.setenv('CHATGPT_EXE', r'C:\Temp\ChatGPT.exe')
+
+    import importlib
+    import automation
+    monkeypatch.setattr(automation, 'pag', pyautogui_stub)
+    monkeypatch.setattr(automation, 'gw', pygetwindow_stub)
+    monkeypatch.setattr(automation, 'pyperclip', pyperclip_stub)
+
+    automation = importlib.reload(automation)
+    bot = automation.ChatGPTAutomation('prompt')
+
+    assert bot.window_title == 'Foo'
+    assert str(automation.CHATGPT_EXE) == os.path.expandvars(r'C:\Temp\ChatGPT.exe')
+


### PR DESCRIPTION
## Summary
- allow environment variables `CHATGPT_EXE` and `CHATGPT_WINDOW_TITLE`
- update README with configuration details
- test environment variable support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867fd0749b4832f834f8d7185477c11