### PR TITLE
Improve ChatGPT focus recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ with the following variables:
 - `CHATGPT_EXE` – full path to `ChatGPT.exe`.
 - `CHATGPT_WINDOW_TITLE` – title of the ChatGPT window to focus on.
 
+BookEase will automatically start ChatGPT Desktop if it's not already
+running, so you can safely close the app between runs.
+
 ## Development workflow
 1. Take or open a Codex task for the change you want to make.
 2. Run `git pull` to ensure `main` is up to date.

--- a/src/automation.py
+++ b/src/automation.py
@@ -48,10 +48,18 @@ class ChatGPTAutomation:
         raise RuntimeError("ChatGPT window did not appear within timeout")
 
     def _focus(self) -> None:
+        """Focus the ChatGPT window, starting the app if necessary."""
+        # Ensure the application is running so ``getWindowsWithTitle`` has
+        # a chance to find the window. ``_ensure_running`` will launch the
+        # executable and wait for the window to appear when needed.
+        self._ensure_running()
+
         wins = gw.getWindowsWithTitle(self.window_title)
         if not wins:
-            raise RuntimeError(f"ChatGPT window titled '{self.window_title}' not found. "
-                            "Start the desktop app and try again.")
+            raise RuntimeError(
+                f"ChatGPT window titled '{self.window_title}' not found. "
+                "Start the desktop app and try again."
+            )
         win = wins[0]
         win.activate()
         time.sleep(0.2)


### PR DESCRIPTION
## Summary
- improve focus logic by restarting ChatGPT if it's closed
- document new auto-start behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686800a34bfc832fb219169d05e58d7b