### PR TITLE
Implement focus retry logic

### DIFF
--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -18,11 +18,19 @@ def ask_gpt(
     total: int,
     chunk: str,
     tool: language_tool_python.LanguageTool,
+    focus_retries: int = 3,
 ) -> str:
     """Send a chunk to ChatGPT and validate the response with LanguageTool."""
     language_failures = 0
     while True:
-        bot._focus()
+        for attempt in range(focus_retries):
+            try:
+                bot._focus()
+            except Exception:
+                if attempt == focus_retries - 1:
+                    raise
+            else:
+                break
         user_msg = prompt_factory.build_user_prompt(file_path, chunk_id, total, chunk)
         bot._paste(user_msg, hit_enter=True)
         try:


### PR DESCRIPTION
## Summary
- allow retrying `_focus` by adding `focus_retries` argument to `ask_gpt`
- retry `_focus` until success or attempts exhausted
- test focus retry behaviour in `tests/test_process_epub.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680ed5b3ac832fabcdfb4e430648b2