### PR TITLE
Implement language failure tolerance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ You can also run the CLI directly:
 ```bash
 python -m src.process_epub --input mybook.epub --output cleaned.epub
 ```
+You can increase the tolerance for LanguageTool warnings with
+`--max-language-failures` (alias `--ignore-language-issues`):
+```bash
+python -m src.process_epub --input mybook.epub --output cleaned.epub \
+    --max-language-failures 5
+```
 
 ### Environment variables
 

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -105,7 +105,7 @@ def test_chunk_count(tmp_path, monkeypatch):
     monkeypatch.setattr(process_epub, 'split_text', stub_split)
 
     calls = []
-    def record(bot, path, idx, total, chunk, tool):
+    def record(bot, path, idx, total, chunk, tool, **kwargs):
         calls.append(chunk)
         return chunk
     monkeypatch.setattr(process_epub, 'ask_gpt', record)

--- a/tests/test_process_epub.py
+++ b/tests/test_process_epub.py
@@ -186,7 +186,7 @@ def test_resume(tmp_path, monkeypatch):
 
     calls = []
 
-    def crash_gpt(bot, path, idx, total, chunk, tool):
+    def crash_gpt(bot, path, idx, total, chunk, tool, **kwargs):
         calls.append(chunk)
         if len(calls) == 4:
             raise RuntimeError('boom')
@@ -209,7 +209,7 @@ def test_resume(tmp_path, monkeypatch):
     calls.clear()
     count = {'n': 0}
 
-    def resume_gpt(bot, path, idx, total, chunk, tool):
+    def resume_gpt(bot, path, idx, total, chunk, tool, **kwargs):
         count['n'] += 1
         return chunk.upper()
 


### PR DESCRIPTION
## Summary
- add `max_language_failures` param to `ask_gpt`
- expose new CLI flag `--max-language-failures` (`--ignore-language-issues` alias)
- warn and return last response when language failures exceed limit
- extend language tool tests for new behaviour
- update tests stubs for new param
- document the new CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686812548fb4832f81cc334f96e58409