### PR TITLE
Add read failure limit to ask_gpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ You can increase the tolerance for LanguageTool warnings with
 python -m src.process_epub --input mybook.epub --output cleaned.epub \
     --max-language-failures 5
 ```
+Similarly, you can cap the number of consecutive clipboard read failures with
+`--max-read-failures`:
+```bash
+python -m src.process_epub --input mybook.epub --output cleaned.epub \
+    --max-read-failures 3
+```
 
 ### Environment variables
 

--- a/tests/test_languagetool.py
+++ b/tests/test_languagetool.py
@@ -87,3 +87,21 @@ def test_language_failures_capped(monkeypatch):
         bot, 'file', 1, 1, 'prompt', tool, max_language_failures=1
     )
     assert result == 'bad'
+
+
+def test_read_failures_capped(monkeypatch):
+    bot = DummyBot()
+    count = {'n': 0}
+
+    def always_fail():
+        count['n'] += 1
+        raise RuntimeError('no clip')
+
+    monkeypatch.setattr(process_epub, 'read_response', always_fail)
+    tool = types.SimpleNamespace(check=lambda txt: [])
+    result = process_epub.ask_gpt(
+        bot, 'file', 1, 1, 'prompt', tool, max_read_failures=2
+    )
+    assert result == ''
+    assert count['n'] == 2
+    assert len(bot.calls) == 4


### PR DESCRIPTION
## Summary
- add `max_read_failures` parameter and failure handling to `ask_gpt`
- expose new option via CLI
- extend tests to cover read failure limit
- document `--max-read-failures`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681b40ee00832f90b684c42f79af0f