### PR TITLE
Move logging setup to CLI entry

### DIFF
--- a/src/automation.py
+++ b/src/automation.py
@@ -2,8 +2,6 @@ import time, pyautogui as pag, pygetwindow as gw, pyperclip
 import subprocess, os, pathlib, sys, re
 import logging
 
-logging.basicConfig(level=logging.INFO)
-
 # Determine the location of the ChatGPT desktop executable.
 # ``pathlib.Path`` does not provide ``expandvars`` like ``os.path`` does, so we
 # expand the environment variables in the string first and then create a

--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -73,6 +73,7 @@ def ask_gpt(
               help='Maximum consecutive read_response failures before giving up')
 def main(input_path: str, output_path: str, max_language_failures: int,
          max_read_failures: int) -> None:
+    logging.basicConfig(level=logging.INFO)
     bot = ChatGPTAutomation("You are a helpful assistant.")
     bot.bootstrap()
     bot._paste(prompt_factory.build_system_prompt(), hit_enter=True)


### PR DESCRIPTION
## Summary
- stop configuring logging on import in `automation.py`
- initialize logging inside `process_epub.main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681f86f69c832f94b0553058bf0e34