### PR TITLE
Refactor config loading

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -37,13 +37,11 @@ def _load_config(path: Path = CONFIG_PATH) -> dict:
     return data
 
 
-_config = _load_config()
-copy_icon_templates = _config["copy_icon_templates"]
-chunk_size = _config["chunk_size"]
-chunk_overlap = _config["chunk_overlap"]
-typing_indicator_bbox = _config["typing_indicator_bbox"]
+def load_config(path: Path = CONFIG_PATH) -> dict:
+    """Return the configuration dictionary, loading it from ``path``."""
+    return _load_config(path)
 
 
-def get_copy_icons() -> list:
+def get_copy_icons(path: Path = CONFIG_PATH) -> list:
     """Return list of template image paths for the Copy icon."""
-    return list(copy_icon_templates)
+    return list(load_config(path)["copy_icon_templates"])

--- a/src/ui_capture.py
+++ b/src/ui_capture.py
@@ -3,9 +3,6 @@ from typing import Optional, Tuple
 
 from src import config
 
-# Trigger config loading and retain for backward compatibility
-_TEMPLATE_PATHS = config.get_copy_icons()
-
 
 def locate_copy_icon(region=None) -> Optional[Tuple[int, int, int, int]]:
     """Locate the ChatGPT Desktop Copy button on screen.
@@ -20,7 +17,7 @@ def locate_copy_icon(region=None) -> Optional[Tuple[int, int, int, int]]:
     tuple or None
         Bounding box of the located icon or None if not found.
     """
-    for path in config.copy_icon_templates:
+    for path in config.load_config().get("copy_icon_templates", []):
         box = pyautogui.locateOnScreen(path, region=region)
         if box:
             return box

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,11 +17,12 @@ def test_defaults_created(monkeypatch):
     monkeypatch.setattr(yaml, 'safe_load', lambda *a, **k: {})
 
     cfg = importlib.reload(config)
+    data = cfg.load_config()
 
-    assert cfg.copy_icon_templates == cfg.DEFAULT_CONFIG['copy_icon_templates']
-    assert cfg.chunk_size == cfg.DEFAULT_CONFIG['chunk_size']
-    assert cfg.chunk_overlap == cfg.DEFAULT_CONFIG['chunk_overlap']
-    assert cfg.typing_indicator_bbox == cfg.DEFAULT_CONFIG['typing_indicator_bbox']
+    assert data['copy_icon_templates'] == cfg.DEFAULT_CONFIG['copy_icon_templates']
+    assert data['chunk_size'] == cfg.DEFAULT_CONFIG['chunk_size']
+    assert data['chunk_overlap'] == cfg.DEFAULT_CONFIG['chunk_overlap']
+    assert data['typing_indicator_bbox'] == cfg.DEFAULT_CONFIG['typing_indicator_bbox']
 
 
 def test_partial_config(monkeypatch):
@@ -34,8 +35,9 @@ def test_partial_config(monkeypatch):
     monkeypatch.setattr(yaml, 'safe_dump', lambda data, stream: None)
 
     cfg = importlib.reload(config)
+    data = cfg.load_config()
 
-    assert cfg.chunk_size == 42
-    assert cfg.chunk_overlap == cfg.DEFAULT_CONFIG['chunk_overlap']
-    assert cfg.copy_icon_templates == cfg.DEFAULT_CONFIG['copy_icon_templates']
-    assert cfg.typing_indicator_bbox == cfg.DEFAULT_CONFIG['typing_indicator_bbox']
+    assert data['chunk_size'] == 42
+    assert data['chunk_overlap'] == cfg.DEFAULT_CONFIG['chunk_overlap']
+    assert data['copy_icon_templates'] == cfg.DEFAULT_CONFIG['copy_icon_templates']
+    assert data['typing_indicator_bbox'] == cfg.DEFAULT_CONFIG['typing_indicator_bbox']

--- a/tests/test_ui_capture.py
+++ b/tests/test_ui_capture.py
@@ -34,7 +34,7 @@ def test_click_copy_icon_found(monkeypatch):
     monkeypatch.setattr(pyautogui_stub, 'locateOnScreen', fake_locate)
     monkeypatch.setattr(pyautogui_stub, 'click', fake_click)
     monkeypatch.setattr(pyautogui_stub, 'moveTo', fake_move)
-    monkeypatch.setattr(config, 'copy_icon_templates', ['dummy'])
+    monkeypatch.setattr(config, 'load_config', lambda: {'copy_icon_templates': ['dummy']})
 
     result = click_copy_icon()
 
@@ -55,7 +55,7 @@ def test_click_copy_icon_not_found(monkeypatch):
     monkeypatch.setattr(pyautogui_stub, 'locateOnScreen', fake_locate)
     monkeypatch.setattr(pyautogui_stub, 'click', fake_click)
     monkeypatch.setattr(pyautogui_stub, 'moveTo', lambda *a, **k: called.__setitem__('moved', True))
-    monkeypatch.setattr(config, 'copy_icon_templates', ['dummy'])
+    monkeypatch.setattr(config, 'load_config', lambda: {'copy_icon_templates': ['dummy']})
 
     result = click_copy_icon()
 


### PR DESCRIPTION
## Summary
- implement `load_config` to fetch configuration on demand
- update UI capture module to call `load_config`
- rewrite config tests for new function
- patch UI capture tests with `load_config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681f8753f8832fac672cc69a819e18