### PR TITLE
Improve ChatGPT path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ following variables:
 - `CHATGPT_WINDOW_TITLE` – substring or regular expression used to locate the
   ChatGPT window.
 
+If `CHATGPT_EXE` isn't set, BookEase searches for `ChatGPT.exe` in the following
+locations, in order:
+
+1. `%LOCALAPPDATA%\Programs\chatgpt\ChatGPT.exe`
+2. `%LOCALAPPDATA%\Programs\ChatGPT\ChatGPT.exe`
+3. `%LOCALAPPDATA%\Microsoft\WindowsApps\ChatGPT.exe`
+4. `C:\Program Files\ChatGPT\ChatGPT.exe`
+5. `C:\Program Files (x86)\ChatGPT\ChatGPT.exe`
+
 Once detected, the window handle is reused so changing the title later will not
 interrupt automation.
 


### PR DESCRIPTION
## Summary
- check several standard locations for `ChatGPT.exe`
- fall back to the first existing executable when `CHATGPT_EXE` isn't set
- document the search order for ChatGPT Desktop

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681f8aaa08832f947dede6685f40ef