### PR TITLE
Fix CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BookEase Formatter
 
-[![CI](https://github.com/<owner>/BookEase---Formatter/actions/workflows/ci.yml/badge.svg)](https://github.com/<owner>/BookEase---Formatter/actions/workflows/ci.yml)
+[![CI](https://github.com/ZainNatour/BookEase---Formatter/actions/workflows/ci.yml/badge.svg)](https://github.com/ZainNatour/BookEase---Formatter/actions/workflows/ci.yml)
 
 BookEase Formatter uses ChatGPT to proofread and clean up EPUB files.
 


### PR DESCRIPTION
## Summary
- update CI badge owner in README

## Testing
- `pytest -q`
- `curl -sI https://github.com/ZainNatour/BookEase---Formatter/actions/workflows/ci.yml/badge.svg`
- `curl -sI https://github.com/ZainNatour/BookEase---Formatter/actions/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68681f8bac4c832fbc71098930c5d3b9