### PR TITLE
Implement global GPT failure limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Similarly, you can cap the number of consecutive clipboard read failures with
 python -m src.process_epub --input mybook.epub --output cleaned.epub \
     --max-read-failures 3
 ```
+To stop processing entirely after too many GPT failures, use
+`--max-total-failures`:
+```bash
+python -m src.process_epub --input mybook.epub --output cleaned.epub \
+    --max-total-failures 10
+```
 
 ### Environment variables
 


### PR DESCRIPTION
## Summary
- add `GPTResult` to track partial chunk failures
- support `--max-total-failures` option in `process_epub`
- stop processing when language/read errors exceed the limit
- test early exit behaviour
- refine logging messages and enable default logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681f928760832fbc83c2874a54ccb0