### PR TITLE
Handle non UTF-8 entries

### DIFF
--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -135,7 +135,13 @@ def main(
             data = zin.read(name)
             ext = Path(name).suffix.lower()
             if ext in {'.xhtml', '.opf', '.ncx', '.css'}:
-                text = data.decode('utf-8')
+                try:
+                    text = data.decode('utf-8')
+                except UnicodeDecodeError:
+                    logging.warning(
+                        "Failed to decode %s with UTF-8; using replacement", name
+                    )
+                    text = data.decode('utf-8', errors='replace')
                 new_parts = []
                 done = set(progress.get(name, []))
                 chunks = list(split_text(text))


### PR DESCRIPTION
## Summary
- handle decoding failures when reading EPUB entries
- warn and fall back to replacement characters if decode fails
- test processing of an EPUB with a CP1252 encoded file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685bb01be8832f9f7c589e5a619916