### PR TITLE
Detect login screen

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,3 +8,4 @@ typing_indicator_bbox:
 - 850
 - 50
 - 20
+login_screen_templates: []

--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,7 @@ DEFAULT_CONFIG = {
     "chunk_size": 1500,
     "chunk_overlap": 200,
     "typing_indicator_bbox": [1150, 850, 50, 20],
+    "login_screen_templates": [],
 }
 
 
@@ -45,3 +46,8 @@ def load_config(path: Path = CONFIG_PATH) -> dict:
 def get_copy_icons(path: Path = CONFIG_PATH) -> list:
     """Return list of template image paths for the Copy icon."""
     return list(load_config(path)["copy_icon_templates"])
+
+
+def get_login_templates(path: Path = CONFIG_PATH) -> list:
+    """Return template paths used to detect the login screen."""
+    return list(load_config(path)["login_screen_templates"])

--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -8,7 +8,7 @@ import logging
 from src import prompt_factory
 
 from utils.chunking import split_text
-from src.automation import ChatGPTAutomation, read_response
+from src.automation import ChatGPTAutomation, read_response, LoginRequiredError
 import language_tool_python
 
 
@@ -152,16 +152,19 @@ def main(
                     if idx in done:
                         new_parts.append(chunk)
                         continue
-                    result = ask_gpt(
-                        bot,
-                        name,
-                        idx + 1,
-                        total,
-                        chunk,
-                        tool,
-                        max_language_failures=max_language_failures,
-                        max_read_failures=max_read_failures,
-                    )
+                    try:
+                        result = ask_gpt(
+                            bot,
+                            name,
+                            idx + 1,
+                            total,
+                            chunk,
+                            tool,
+                            max_language_failures=max_language_failures,
+                            max_read_failures=max_read_failures,
+                        )
+                    except LoginRequiredError as e:
+                        raise SystemExit(str(e))
                     new_parts.append(result)
                     processed_chunks += 1
                     if getattr(result, 'failed', False):

--- a/src/ui_capture.py
+++ b/src/ui_capture.py
@@ -33,3 +33,11 @@ def click_copy_icon() -> bool:
         pyautogui.click()
         return True
     return False
+
+
+def detect_login_screen() -> bool:
+    """Return ``True`` if the ChatGPT login screen is visible."""
+    for path in config.load_config().get("login_screen_templates", []):
+        if pyautogui.locateOnScreen(path) is not None:
+            return True
+    return False

--- a/tests/test_read_response.py
+++ b/tests/test_read_response.py
@@ -60,6 +60,7 @@ def test_read_response(monkeypatch, icon_ret, empties, expected, hotkey_count):
     monkeypatch.setattr(automation, '_scroll_to_bottom', lambda: None)
     ui_stub = types.SimpleNamespace(click_copy_icon=lambda: icon_ret)
     monkeypatch.setitem(sys.modules, 'ui_capture', ui_stub)
+    monkeypatch.setitem(sys.modules, 'src.ui_capture', ui_stub)
 
     values = [''] * empties + [expected]
 
@@ -72,4 +73,19 @@ def test_read_response(monkeypatch, icon_ret, empties, expected, hotkey_count):
 
     assert result == expected
     assert hotkeys == [('ctrl', 'a'), ('ctrl', 'c')] * (hotkey_count // 2)
+
+
+def test_read_response_login(monkeypatch):
+    hotkeys.clear()
+    monkeypatch.setattr(automation, '_scroll_to_bottom', lambda: None)
+    ui_stub = types.SimpleNamespace(
+        click_copy_icon=lambda: False,
+        detect_login_screen=lambda: True,
+    )
+    monkeypatch.setitem(sys.modules, 'ui_capture', ui_stub)
+    monkeypatch.setitem(sys.modules, 'src.ui_capture', ui_stub)
+    monkeypatch.setattr(pyperclip_stub, 'paste', lambda: '')
+
+    with pytest.raises(automation.LoginRequiredError):
+        automation.read_response()
 


### PR DESCRIPTION
## Summary
- add login screen templates to config
- implement `LoginRequiredError` and login detection in `read_response`
- expose login screen templates in `config`
- add `detect_login_screen` helper
- handle login errors in `process_epub`
- test login detection scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686863dd1488832f8ac0a9be2801d2e8