### PR TITLE
Use factory system prompt

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from tkinter import filedialog
 
 from src.automation import ChatGPTAutomation
 from src.process_epub import main as process_epub
+from src import prompt_factory
 
 
 def choose_epub() -> None:
@@ -39,7 +40,7 @@ def quit_program() -> None:
 
 
 if __name__ == "__main__":
-    bot = ChatGPTAutomation("You are a helpful assistant.")
+    bot = ChatGPTAutomation(prompt_factory.build_system_prompt())
     bot.bootstrap()
 
     keyboard.add_hotkey("ctrl+shift+e", choose_epub)

--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -112,7 +112,7 @@ def main(
     max_total_failures: int,
 ) -> None:
     logging.basicConfig(level=logging.INFO)
-    bot = ChatGPTAutomation("You are a helpful assistant.")
+    bot = ChatGPTAutomation(prompt_factory.build_system_prompt())
     bot.bootstrap()
 
     lt_path = os.getenv("LANGTOOL_PATH")


### PR DESCRIPTION
## Summary
- use `prompt_factory.build_system_prompt()` for ChatGPTAutomation
- update EPUB processing tests
- verify system prompt is passed to `ChatGPTAutomation`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c860cc0832f92a53529692d708f