### PR TITLE
Handle login retries

### DIFF
--- a/src/automation.py
+++ b/src/automation.py
@@ -200,8 +200,18 @@ def read_response(verbose: bool = False):
             print(f"Login check failed: {e}", file=sys.stderr)
     else:
         if login:
-            raise LoginRequiredError(
-                "ChatGPT appears to be logged out; please sign in and retry"
+            prompt = (
+                "ChatGPT appears to be logged out. Log in and press Enter to "
+                "retry, or type 'q' to quit: "
             )
+            try:
+                ans = input(prompt)
+            except EOFError:
+                ans = "q"
+            if ans.strip().lower().startswith("q"):
+                raise LoginRequiredError(
+                    "ChatGPT appears to be logged out; please sign in and retry"
+                )
+            return read_response(verbose=verbose)
 
     raise RuntimeError("Clipboard remained empty after 5 attempts")

--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -52,6 +52,15 @@ def ask_gpt(
         bot._paste(user_msg, hit_enter=True)
         try:
             reply = read_response()
+        except LoginRequiredError as e:
+            prompt = f"{e} Press Enter to retry or type 'q' to quit: "
+            try:
+                ans = input(prompt)
+            except EOFError:
+                ans = 'q'
+            if ans.strip().lower().startswith('q'):
+                raise
+            continue
         except RuntimeError:
             read_failures += 1
             if read_failures >= max_read_failures:


### PR DESCRIPTION
## Summary
- prompt for login when clipboard appears empty and retry in `read_response`
- allow retry or exit if `LoginRequiredError` happens in `ask_gpt`
- test login retry handling in both helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c907178832fa58c0bcf5f4f4794