### PR TITLE
Refactor split_text generator

### DIFF
--- a/src/process_epub.py
+++ b/src/process_epub.py
@@ -152,9 +152,8 @@ def main(
                     text = data.decode('utf-8', errors='replace')
                 new_parts = []
                 done = set(progress.get(name, []))
-                chunks = list(split_text(text))
-                total = len(chunks)
-                for idx, chunk in enumerate(chunks):
+                total = sum(1 for _ in split_text(text))
+                for idx, chunk in enumerate(split_text(text)):
                     if idx in done:
                         new_parts.append(chunk)
                         continue

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -100,8 +100,10 @@ def test_chunk_count(tmp_path, monkeypatch):
     chunks = ['a', 'b', 'c']
     def stub_split(text):
         if text.startswith('<html'):
-            return list(chunks)
-        return [text]
+            for c in chunks:
+                yield c
+        else:
+            yield text
     monkeypatch.setattr(process_epub, 'split_text', stub_split)
 
     calls = []

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -44,7 +44,7 @@ def test_html_paragraph_split(monkeypatch):
     )
 
     text = "<p>one</p><p>two</p>"
-    chunks = split_text(text, size=50, overlap=0)
+    chunks = list(split_text(text, size=50, overlap=0))
 
     assert len(chunks) == 2
     assert chunks[0].strip() == "<p>one</p>"
@@ -61,7 +61,7 @@ def test_nested_and_uppercase_tags(monkeypatch):
     )
 
     text = "<P>ONE <b>two <i>THREE</i></b></P><p>four</p>"
-    chunks = split_text(text, size=100, overlap=0)
+    chunks = list(split_text(text, size=100, overlap=0))
 
     assert chunks[0].strip() == "<P>ONE <b>two <i>THREE</i></b></P>"
     assert chunks[1].strip() == "<p>four</p>"
@@ -77,7 +77,7 @@ def test_overlap(monkeypatch):
     )
 
     text = "abcdefghi"
-    chunks = split_text(text, size=5, overlap=2)
+    chunks = list(split_text(text, size=5, overlap=2))
 
     # Ensure second chunk starts with the last 2 chars of the first chunk
     assert chunks[1].startswith(chunks[0][-2:])

--- a/tests/test_langtool_path.py
+++ b/tests/test_langtool_path.py
@@ -43,7 +43,7 @@ class DummySplitter:
     def __init__(self, chunk_size, chunk_overlap, separators):
         pass
     def split_text(self, text):
-        return [text]
+        yield text
 
 def stub_from_tiktoken_encoder(chunk_size=1500, chunk_overlap=200, separators=None):
     return DummySplitter(chunk_size, chunk_overlap, separators or ['</p>'])

--- a/utils/chunking.py
+++ b/utils/chunking.py
@@ -39,26 +39,28 @@ class _ParagraphParser(HTMLParser):
             self._buf.append(data)
 
 
-def split_text(text: str, size: int = 1500, overlap: int = 200) -> list[str]:
-    """Split ``text`` into overlapping chunks without external dependencies."""
+from collections.abc import Iterator
+
+
+def split_text(text: str, size: int = 1500, overlap: int = 200) -> Iterator[str]:
+    """Yield ``text`` as overlapping chunks without building a list."""
 
     parser = _ParagraphParser()
     parser.feed(text)
     pieces = parser.paragraphs or [text]
 
-    chunks: list[str] = []
+    prev_chunk: str | None = None
     for piece in pieces:
         start = 0
         first = True
         while True:
             end = start + size
             chunk = piece[start:end]
-            if first and chunks and overlap > 0:
-                chunk = chunks[-1][-overlap:] + chunk
-            chunks.append(chunk)
+            if first and prev_chunk is not None and overlap > 0:
+                chunk = prev_chunk[-overlap:] + chunk
+            yield chunk
+            prev_chunk = chunk
             if end >= len(piece):
                 break
             start = end - overlap
             first = False
-
-    return chunks


### PR DESCRIPTION
## Summary
- refactor `split_text` to yield chunks lazily
- count total chunks without pre-building lists
- update callers and unit tests to work with generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c92a558832f9703ca99afcce657